### PR TITLE
Separate demo Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "pathRules": [
+    {
+      "paths": ["demo/**"],
+      "branchPrefix": ["renovate/demo-"]
+    }
   ]
 }


### PR DESCRIPTION
Adds a custom `branchPrefix` to ensure separation of PRs between the main `package.json` and the demo one.