### PR TITLE
handling output options

### DIFF
--- a/projects/ng-katex/src/lib/ng-katex.options.ts
+++ b/projects/ng-katex/src/lib/ng-katex.options.ts
@@ -5,4 +5,5 @@ export type KatexOptions = {
   macros?: object;
   colorIsTextColor?: boolean;
   maxSize?: number;
-}
+  output?: string;
+};


### PR DESCRIPTION
# PR Details

Adding 'output' options to KatexOptions.

## Description

Adding 'output' options to KatexOptions.

## Related Issue

#[594](https://github.com/garciparedes/ng-katex/issues/594)

## Motivation and Context

I tried to use ng-katex and as I was trying to print equations I came accross the fact that Katex now have an 'output' option, which allows the user to choose between Mathml, Html or HtmlAndMathml. The last one being the default value, accoding to Katex [doc](https://katex.org/docs/options.html). That's why ng-katex was only printing two equations every time.

## How Has This Been Tested

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
