### PR TITLE
add types/katex, import options from katex and optimize import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2574,6 +2574,12 @@
         "@types/node": "*"
       }
     },
+    "@types/katex": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.11.0.tgz",
+      "integrity": "sha512-27BfE8zASRLYfSBNMk5/+KIjr2CBBrH0i5lhsO04fca4TGirIIMay73v3zNkzqmsaeIa/Mi5kejWDcxPLAmkvA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@angular/platform-browser": "8.2.14",
     "@angular/platform-browser-dynamic": "8.2.14",
     "@angular/router": "8.2.14",
+    "@types/katex": "^0.11.0",
     "clean-css": "4.2.2",
     "ng-packagr": "9.1.5",
     "node-sass": "4.14.1",

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { KatexOptions } from 'ng-katex';
+import { KatexOptions } from 'katex';
 
 @Component({
   selector: 'app-root',

--- a/projects/ng-katex/src/lib/ng-katex.component.ts
+++ b/projects/ng-katex/src/lib/ng-katex.component.ts
@@ -3,9 +3,8 @@ import {
   EventEmitter,
   Input,
   Output,
-  ViewEncapsulation,
 } from '@angular/core';
-import * as ko from './ng-katex.options';
+import { KatexOptions } from 'katex';
 
 @Component({
   selector: 'ng-katex',
@@ -19,7 +18,7 @@ import * as ko from './ng-katex.options';
 export class KatexComponent {
 
   @Input() equation: string;
-  @Input() options?: ko.KatexOptions;
+  @Input() options?: KatexOptions;
   @Output() onError = new EventEmitter<any>();
 
   hasError(error) {

--- a/projects/ng-katex/src/lib/ng-katex.directive.ts
+++ b/projects/ng-katex/src/lib/ng-katex.directive.ts
@@ -6,7 +6,7 @@ import {
   Output,
 } from '@angular/core';
 import { KatexService } from './ng-katex.service';
-import * as ko from './ng-katex.options';
+import { KatexOptions } from 'katex';
 
 @Directive({
   selector: '[katex]',
@@ -14,7 +14,7 @@ import * as ko from './ng-katex.options';
 export class KatexDirective {
 
   @Input('katex') equation: string;
-  @Input('katex-options') options: ko.KatexOptions;
+  @Input('katex-options') options: KatexOptions;
 
   @Output() onError = new EventEmitter<any>();
 

--- a/projects/ng-katex/src/lib/ng-katex.options.ts
+++ b/projects/ng-katex/src/lib/ng-katex.options.ts
@@ -1,9 +1,0 @@
-export type KatexOptions = {
-  displayMode?: boolean;
-  throwOnError?: boolean;
-  errorColor?: string;
-  macros?: object;
-  colorIsTextColor?: boolean;
-  maxSize?: number;
-  output?: string;
-};

--- a/projects/ng-katex/src/lib/ng-katex.service.ts
+++ b/projects/ng-katex/src/lib/ng-katex.service.ts
@@ -1,16 +1,14 @@
 import { ElementRef, Injectable } from '@angular/core';
-import * as ko from './ng-katex.options';
-
-import * as katex from 'katex';
+import { render, renderToString, KatexOptions } from 'katex';
 
 @Injectable()
 export class KatexService {
 
-  render(equation: string, element: ElementRef, options?: ko.KatexOptions) {
-    return katex.render(equation, element.nativeElement, options);
+  render(equation: string, element: ElementRef, options?: KatexOptions) {
+    return render(equation, element.nativeElement, options);
   }
 
-  renderToString(equation: string, options?: ko.KatexOptions): string {
-    return katex.renderToString(equation, options);
+  renderToString(equation: string, options?: KatexOptions): string {
+    return renderToString(equation, options);
   }
 }

--- a/projects/ng-katex/src/lib/ng-katex.ts
+++ b/projects/ng-katex/src/lib/ng-katex.ts
@@ -1,4 +1,3 @@
-export * from './ng-katex.options';
 export * from './ng-katex.component';
 export * from './ng-katex-paragraph.component';
 export * from './ng-katex.module';

--- a/projects/ng-katex/src/public-api.ts
+++ b/projects/ng-katex/src/public-api.ts
@@ -1,7 +1,6 @@
 /*
  * Public API Surface of ng-katex
  */
-export * from './lib/ng-katex.options';
 export * from './lib/ng-katex.component';
 export * from './lib/ng-katex-paragraph.component';
 export * from './lib/ng-katex.module';


### PR DESCRIPTION
# PR Details

Update import from katex.
Add @types/katex to make imports possible.
Delete KatexOptions from ng-katex to use KatexOptions of katex to have a correct type checking


## Related Issue

Issue #652 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
I don't know
- [ ] My change requires a change to the documentation.
Maybe because of the KatexOptions
- [ ] I have updated the documentation accordingly.
No
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
Didn't find any tests
