### PR TITLE
Export KatexService

### DIFF
--- a/projects/ng-katex/src/public-api.ts
+++ b/projects/ng-katex/src/public-api.ts
@@ -4,3 +4,4 @@
 export * from './lib/ng-katex.component';
 export * from './lib/ng-katex-paragraph.component';
 export * from './lib/ng-katex.module';
+export * from './lib/ng-katex.service';


### PR DESCRIPTION
# PR Details

Exports the KatexService as part of the  Public API Surface of ng-katex

## Description

This MR includes the KatexService as part of the  Public API Surface in ng-katex public-api.ts file

## Related Issue

https://github.com/garciparedes/ng-katex/issues/658

## Motivation and Context
 
Certain requirements needs the renderToString() and render() function currently in the KatexService <br/>
for instance a requirement to include katex in a text-editor will need the renderToString() function in the KatexService,
The current implementation hides the KatexService which prevents the use of the  renderToString().

## How Has This Been Tested

The change is makes no breaking change and has been tested with a work in progress project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
